### PR TITLE
Enable nested schema

### DIFF
--- a/lib/objecheck/validator.rb
+++ b/lib/objecheck/validator.rb
@@ -22,10 +22,9 @@ class Objecheck::Validator
     type: TypeRule
   }.freeze
 
-  def initialize(schema, rules = DEFAULT_RULES)
-    @rules = schema.map do |rule_name, param|
-      rules[rule_name].new(param)
-    end
+  def initialize(schema, rule_map = DEFAULT_RULES)
+    @rule_map = rule_map
+    @rules = compile_schema(schema)
   end
 
   def validate(target)
@@ -36,6 +35,12 @@ class Objecheck::Validator
       end
     end
     collector.errors
+  end
+
+  def compile_schema(schema)
+    schema.map do |rule_name, param|
+      @rule_map[rule_name].new(param)
+    end
   end
 end
 

--- a/lib/objecheck/validator.rb
+++ b/lib/objecheck/validator.rb
@@ -39,7 +39,7 @@ class Objecheck::Validator
 
   def compile_schema(schema)
     schema.map do |rule_name, param|
-      @rule_map[rule_name].new(param)
+      @rule_map[rule_name].new(self, param)
     end
   end
 end

--- a/lib/objecheck/validator.rb
+++ b/lib/objecheck/validator.rb
@@ -30,9 +30,7 @@ class Objecheck::Validator
   def validate(target)
     collector = Collector.new(self)
     collector.add_prefix_in('root') do
-      @rules.each do |rule|
-        rule.validate(target, collector)
-      end
+      collector.validate(target, @rules)
     end
     collector.errors
   end

--- a/lib/objecheck/validator/collector.rb
+++ b/lib/objecheck/validator/collector.rb
@@ -34,6 +34,12 @@ class Objecheck::Validator::Collector
     @errors << "#{@prefix_stack.join('')}: #{msg}"
   end
 
+  def validate(target, rules)
+    rules.each do |rule|
+      rule.validate(target, self)
+    end
+  end
+
   def errors
     @errors.dup
   end

--- a/lib/objecheck/validator/type_rule.rb
+++ b/lib/objecheck/validator/type_rule.rb
@@ -17,7 +17,7 @@
 # TypeRule validates type of a target
 #
 class Objecheck::Validator::TypeRule
-  def initialize(type)
+  def initialize(_validator, type)
     @type = type
   end
 

--- a/spec/objecheck/validator/type_rule_spec.rb
+++ b/spec/objecheck/validator/type_rule_spec.rb
@@ -1,5 +1,5 @@
 describe Objecheck::Validator::TypeRule do
-  let(:rule) { described_class.new(type) }
+  let(:rule) { described_class.new(instance_double(Objecheck::Validator), type) }
   let(:type) { Hash }
 
   describe '#validate' do

--- a/spec/objecheck/validator_spec.rb
+++ b/spec/objecheck/validator_spec.rb
@@ -20,4 +20,14 @@ describe Objecheck::Validator do
       end
     end
   end
+
+  describe '#compile_schema' do
+    subject { validator.compile_schema({ type: Array }) }
+
+    let(:schema) { { type: Hash } }
+
+    it 'returns rules' do
+      expect(subject).to match([a_kind_of(Objecheck::Validator::TypeRule)])
+    end
+  end
 end


### PR DESCRIPTION
Enable nested schema by:

- Constructor of rule receive validator object to compile nested schema
- define `Collector#validate` to validate inner object of target