### PR TITLE
add EachRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ Example schema:
 }
 ```
 
+### `each`
+
+`each` checks elements of the object by using `each`.
+
+Example schema:
+```ruby
+{
+  each: {
+    type: Integer
+  }
+}
+```
+
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/autopp/objecheck.

--- a/lib/objecheck/validator.rb
+++ b/lib/objecheck/validator.rb
@@ -18,8 +18,10 @@
 #
 class Objecheck::Validator
   require 'objecheck/validator/type_rule'
+  require 'objecheck/validator/each_rule'
   DEFAULT_RULES = {
-    type: TypeRule
+    type: TypeRule,
+    each: EachRule
   }.freeze
 
   def initialize(schema, rule_map = DEFAULT_RULES)

--- a/lib/objecheck/validator/each_rule.rb
+++ b/lib/objecheck/validator/each_rule.rb
@@ -1,0 +1,36 @@
+#
+# Objecheck
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# EachRule validates elements in the target by using each
+#
+class Objecheck::Validator::EachRule
+  def initialize(validator, element_schema)
+    @element_rules = validator.compile_schema(element_schema)
+  end
+
+  def validate(target, collector)
+    if !target.respond_to?(:each)
+      collector.add_error('should respond to `each`')
+      return
+    end
+
+    target.each.with_index do |elem, i|
+      collector.add_prefix_in("[#{i}]") do
+        collector.validate(elem, @element_rules)
+      end
+    end
+  end
+end

--- a/spec/objecheck/validator/each_rule_spec.rb
+++ b/spec/objecheck/validator/each_rule_spec.rb
@@ -1,0 +1,54 @@
+describe Objecheck::Validator::EachRule do
+  let(:rule) { described_class.new(validator, element_schema) }
+
+  let(:validator) do
+    validator = instance_double(Objecheck::Validator)
+    rules = { type: Objecheck::Validator::TypeRule.new(validator, Integer) }
+    allow(validator).to receive(:compile_schema).with(element_schema).and_return(rules)
+    validator
+  end
+  let(:element_schema) { { type: Integer } }
+
+  describe '#validate' do
+    subject { rule.validate(target, collector) }
+    let(:collector) { Objecheck::Validator::Collector.new(validator) }
+
+    context 'when target responds to each' do
+      context 'and target is empty' do
+        let(:target) { [] }
+
+        it 'dose not add error to collector' do
+          expect(collector).not_to receive(:add_error)
+          subject
+        end
+      end
+
+      context 'and all elements in target are satisfy the schema' do
+        let(:target) { [1, 2, 3] }
+
+        it 'dose not add error to collector' do
+          expect(collector).not_to receive(:add_error)
+          subject
+        end
+      end
+
+      context 'and some elements in target are not satisfy the schema' do
+        let(:target) { ['1', 2, '3'] }
+
+        it 'dose not add error to collector' do
+          expect(collector).to receive(:add_error).twice
+          subject
+        end
+      end
+    end
+
+    context 'when target dose not respond to each' do
+      let(:target) { nil }
+
+      it 'add error to collector' do
+        expect(collector).to receive(:add_error).with('should respond to `each`')
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `EachRule` which validates elements of the target by using `each`

E.g:
```ruby
validator = Objecheck::Validator.new({ each: { type: Integer } })

p validator.validate([]) # no error
p validator.validate([1, 2, 3]) # no error
p validator.validate(['1', 2, '3']) # two errors
```