### PR TITLE
add EachKeyRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ Example schema:
 }
 ```
 
+### `each_key`
+
+`each_key` checks keys of the object by using `each_keya`.
+
+Example schema:
+```ruby
+{
+  each_key: {
+    type: Symbol
+  }
+}
+```
 
 ## Contributing
 

--- a/lib/objecheck/validator.rb
+++ b/lib/objecheck/validator.rb
@@ -19,9 +19,11 @@
 class Objecheck::Validator
   require 'objecheck/validator/type_rule'
   require 'objecheck/validator/each_rule'
+  require 'objecheck/validator/each_key_rule'
   DEFAULT_RULES = {
     type: TypeRule,
-    each: EachRule
+    each: EachRule,
+    each_key: EachKeyRule
   }.freeze
 
   def initialize(schema, rule_map = DEFAULT_RULES)

--- a/lib/objecheck/validator/each_key_rule.rb
+++ b/lib/objecheck/validator/each_key_rule.rb
@@ -1,0 +1,36 @@
+#
+# Objecheck
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# EachKeyRule validates keys in the target by using each_key
+#
+class Objecheck::Validator::EachKeyRule
+  def initialize(validator, key_schema)
+    @key_rules = validator.compile_schema(key_schema)
+  end
+
+  def validate(target, collector)
+    if !target.respond_to?(:each_key)
+      collector.add_error('should respond to `each_key`')
+      return
+    end
+
+    target.each_key do |key|
+      collector.add_prefix_in("[#{key.inspect}]") do
+        collector.validate(key, @key_rules)
+      end
+    end
+  end
+end

--- a/spec/objecheck/validator/each_key_rule_spec.rb
+++ b/spec/objecheck/validator/each_key_rule_spec.rb
@@ -1,0 +1,54 @@
+describe Objecheck::Validator::EachKeyRule do
+  let(:rule) { described_class.new(validator, element_schema) }
+
+  let(:validator) do
+    validator = instance_double(Objecheck::Validator)
+    rules = { type: Objecheck::Validator::TypeRule.new(validator, Symbol) }
+    allow(validator).to receive(:compile_schema).with(element_schema).and_return(rules)
+    validator
+  end
+  let(:element_schema) { { type: Symbol } }
+
+  describe '#validate' do
+    subject { rule.validate(target, collector) }
+    let(:collector) { Objecheck::Validator::Collector.new(validator) }
+
+    context 'when target responds to each_key' do
+      context 'and target is empty' do
+        let(:target) { {} }
+
+        it 'dose not add error to collector' do
+          expect(collector).not_to receive(:add_error)
+          subject
+        end
+      end
+
+      context 'and all elements in target are satisfy the schema' do
+        let(:target) { { a: 1, b: 2, c: 3 } }
+
+        it 'dose not add error to collector' do
+          expect(collector).not_to receive(:add_error)
+          subject
+        end
+      end
+
+      context 'and some elements in target are not satisfy the schema' do
+        let(:target) { { 'a' => 1, b: 2, 'c' => 3 } }
+
+        it 'dose not add error to collector' do
+          expect(collector).to receive(:add_error).twice
+          subject
+        end
+      end
+    end
+
+    context 'when target dose not respond to each_key' do
+      let(:target) { nil }
+
+      it 'add error to collector' do
+        expect(collector).to receive(:add_error).with('should respond to `each_key`')
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `EachKeyRule` which validates keys of the target by using `each_key`

E.g:
```ruby
validator = Objecheck::Validator.new({ each_key: { type: Symbol } })

p validator.validate({}) # no error
p validator.validate({ a: 1, b: 2, c: 3}) # no error
p validator.validate({ 'a' => 1, b: 2, 'c' => '3' }) # two errors
```