### PR TITLE
Change prefix of each_key

### DIFF
--- a/lib/objecheck/validator/each_key_rule.rb
+++ b/lib/objecheck/validator/each_key_rule.rb
@@ -28,7 +28,7 @@ class Objecheck::Validator::EachKeyRule
     end
 
     target.each_key do |key|
-      collector.add_prefix_in("[#{key.inspect}]") do
+      collector.add_prefix_in(".key(#{key.inspect})") do
         collector.validate(key, @key_rules)
       end
     end


### PR DESCRIPTION
`["a"]` -> `.key("a")`