### PR TITLE
add KeyValueRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ Example schema:
 }
 ```
 
+### `key_value`
+
+`key_value` checks key/values of the object by using `each_pair`.
+
+Example schema:
+```ruby
+{
+  key_value: {
+    name: {
+      value: { type: String }
+    },
+    age: {
+      required: false # Default is true
+      value: { type: Integer }
+    }
+  }
+}
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/autopp/objecheck.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,32 @@ validator = Objecheck::Validator.new({
 # Validator#validate checks the given object and returns error messages as a array
 p validator.validate({ a: 1, b: 2 }) # => []
 p validator.validate([1, 2]) # => ["root: the type should be a Hash (got Array)"]
+
+# Validate type of keys and values
+validator = Objecheck::Validator.new({
+  each_key: { type: Symbol }
+  each_value: { type: Integer }
+})
+
+p validator.validate({ a: 1, b: 2 }) # => []
+
+# Validate array that contains specific key/value
+validator = Objecheck::Validator.new({
+  type: Array,
+  each: {
+    key_value: {
+      name: {
+        value: { type: String }
+      },
+      age: {
+        required: false,
+        value: { type: Integer }
+      }
+    }
+  }
+})
+
+p validator.validate([{ name: 'Jhon', age: 20 }, { name: 'Tom' }]) # => []
 ```
 
 ## Builtin rules

--- a/lib/objecheck/validator.rb
+++ b/lib/objecheck/validator.rb
@@ -21,11 +21,13 @@ class Objecheck::Validator
   require 'objecheck/validator/each_rule'
   require 'objecheck/validator/each_key_rule'
   require 'objecheck/validator/each_value_rule'
+  require 'objecheck/validator/key_value_rule'
   DEFAULT_RULES = {
     type: TypeRule,
     each: EachRule,
     each_key: EachKeyRule,
-    each_value: EachValueRule
+    each_value: EachValueRule,
+    key_value: KeyValueRule
   }.freeze
 
   def initialize(schema, rule_map = DEFAULT_RULES)

--- a/lib/objecheck/validator/key_value_rule.rb
+++ b/lib/objecheck/validator/key_value_rule.rb
@@ -1,0 +1,45 @@
+#
+# Objecheck
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# KeyValueRule validates key/value in the target by using each_pair
+#
+class Objecheck::Validator::KeyValueRule
+  def initialize(validator, key_value_schema)
+    @key_value_rules = key_value_schema.each_with_object({}) do |(key, schema), rules|
+      rules[key] = {
+        required: schema.fetch(:required, true),
+        rule: validator.compile_schema(schema[:value])
+      }
+    end
+  end
+
+  def validate(target, collector)
+    if !target.respond_to?(:each_pair)
+      collector.add_error('should respond to `each_pair`')
+      return
+    end
+
+    @key_value_rules.each_pair do |key, rule|
+      if target.key?(key)
+        collector.add_prefix_in("[#{key.inspect}]") do
+          collector.validate(target[key], rule[:rule])
+        end
+      elsif rule[:required]
+        collector.add_error("should contain key #{key.inspect}")
+      end
+    end
+  end
+end

--- a/spec/objecheck/validator/key_value_rule_spec.rb
+++ b/spec/objecheck/validator/key_value_rule_spec.rb
@@ -1,0 +1,105 @@
+describe Objecheck::Validator::KeyValueRule do
+  let(:rule) { described_class.new(validator, schema) }
+
+  let(:validator) do
+    validator = instance_double(Objecheck::Validator)
+    int_schema = { type: Integer }
+    int_rules = { type: Objecheck::Validator::TypeRule.new(validator, Integer) }
+    allow(validator).to receive(:compile_schema).with(int_schema).and_return(int_rules)
+
+    str_schema = { type: String }
+    str_rules = { type: Objecheck::Validator::TypeRule.new(validator, String) }
+    allow(validator).to receive(:compile_schema).with(str_schema).and_return(str_rules)
+
+    validator
+  end
+
+  describe '#validate' do
+    subject { rule.validate(target, collector) }
+    let(:collector) { Objecheck::Validator::Collector.new(validator) }
+
+    context 'when target responds to each_pair' do
+      context 'and when schema requires :name as String and :age as Integer' do
+        let(:schema) do
+          {
+            name: {
+              value: { type: String }
+            },
+            age: {
+              value: { type: Integer }
+            }
+          }
+        end
+
+        context 'and when target contains required key/value' do
+          let(:target) { { name: 'John', age: 20 } }
+
+          it 'dose not add error to collector' do
+            expect(collector).not_to receive(:add_error)
+            subject
+          end
+        end
+
+        context 'and when target dose not satisfy required schema of key/value' do
+          let(:target) { { name: 20, age: 'Jhon' } }
+
+          it 'add errors to collector' do
+            expect(collector).to receive(:add_error).twice
+            subject
+          end
+        end
+
+        context 'and when target dose not contains required key/value' do
+          let(:target) { { name: 'Jhon' } }
+
+          it 'add errors to collector' do
+            expect(collector).to receive(:add_error).once
+            subject
+          end
+        end
+      end
+
+      context 'and when schema requires :name as String and :age as Integer (optional)' do
+        let(:schema) do
+          {
+            name: {
+              value: { type: String }
+            },
+            age: {
+              required: false,
+              value: { type: Integer }
+            }
+          }
+        end
+
+        context 'and when target contains required key/value' do
+          let(:target) { { name: 'John', age: 20 } }
+
+          it 'dose not add error to collector' do
+            expect(collector).not_to receive(:add_error)
+            subject
+          end
+        end
+
+        context 'and when target dose not contains optional key/value' do
+          let(:target) { { name: 'Jhon' } }
+
+          it 'dose not add error to collector' do
+            expect(collector).not_to receive(:add_error)
+            subject
+          end
+        end
+      end
+    end
+
+    context 'when target dose not respond to each_pair' do
+      let(:schema) { {} }
+      let(:target) { nil }
+
+      it 'add error to collector' do
+        expect(collector).to receive(:add_error).with('should respond to `each_pair`')
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `KeyValueRule` which validates specified key/value of the target by using `each_pair`

E.g.
```ruby
validator = Objecheck::Validator.new({
  key_value: {
    name: {
      value: { type: String }
    },
    age: {
      required: false,
      value: { type: Integer }
    }
  }
})

p validator.validate({ name: 'Jhon', age: 20 }) # => no error
p validator.validate({ name: 'Jhon' }) # => no error
p validator.validate({ age: '20' }) # => two errors
```
