### PR TITLE
Enable  TypeRule to check that object is boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ Example schema:
 }
 ```
 
+When you want to check that value is a boolean (`true` or `false`), use `:bool`.
+```ruby
+{
+  type: :bool
+}
+```
+
 ### `each`
 
 `each` checks elements of the object by using `each`.

--- a/lib/objecheck/validator/type_rule.rb
+++ b/lib/objecheck/validator/type_rule.rb
@@ -22,6 +22,10 @@ class Objecheck::Validator::TypeRule
   end
 
   def validate(target, collector)
-    collector.add_error("should be a #{@type} (got #{target.class})") if !target.is_a?(@type)
+    if @type == :bool
+      collector.add_error("should be a bool (got #{target.class})") if target != true && target != false
+    elsif !target.is_a?(@type)
+      collector.add_error("should be a #{@type} (got #{target.class})")
+    end
   end
 end

--- a/spec/objecheck/validator/type_rule_spec.rb
+++ b/spec/objecheck/validator/type_rule_spec.rb
@@ -23,5 +23,36 @@ describe Objecheck::Validator::TypeRule do
         subject
       end
     end
+
+    context 'when the given type is :bool' do
+      let(:type) { :bool }
+
+      context 'when target is true' do
+        let(:target) { true }
+
+        it 'dose not add error to collector' do
+          expect(collector).not_to receive(:add_error)
+          subject
+        end
+      end
+
+      context 'when target is false' do
+        let(:target) { false }
+
+        it 'dose not add error to collector' do
+          expect(collector).not_to receive(:add_error)
+          subject
+        end
+      end
+
+      context 'when target is not boolean' do
+        let(:target) { 42 }
+
+        it 'add error to collector' do
+          expect(collector).to receive(:add_error).with('should be a bool (got Integer)')
+          subject
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix #14.
To check boolean, specify `:bool` instead of class/module.
```ruby
{
  type: :bool
}
```