### PR TITLE
Add regexp rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,17 @@ Example schema:
 }
 ```
 
+### `regexp`
+
+`regexp` checks pattern by regular expression.
+
+Example schema:
+```ruby
+{
+  regexp: /\A[a-zA-Z_]\w*\z/
+}
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/autopp/objecheck.

--- a/lib/objecheck/validator.rb
+++ b/lib/objecheck/validator.rb
@@ -26,6 +26,7 @@ class Objecheck::Validator
   require 'objecheck/validator/any_rule'
   require 'objecheck/validator/satisfy_rule'
   require 'objecheck/validator/respond_to_rule'
+  require 'objecheck/validator/regexp_rule'
   DEFAULT_RULES = {
     type: TypeRule,
     each: EachRule,
@@ -35,7 +36,8 @@ class Objecheck::Validator
     eq: EqRule,
     any: AnyRule,
     satisfy: SatisfyRule,
-    respond_to: RespondToRule
+    respond_to: RespondToRule,
+    regexp: RegexpRule
   }.freeze
 
   def initialize(schema, rule_map = DEFAULT_RULES, schema_validation = true)

--- a/lib/objecheck/validator/regexp_rule.rb
+++ b/lib/objecheck/validator/regexp_rule.rb
@@ -26,4 +26,8 @@ class Objecheck::Validator::RegexpRule
   rescue TypeError
     collector.add_error("should be acceptable to Regexp (type is #{target.class})")
   end
+
+  def self.schema
+    [{ type: Regexp }]
+  end
 end

--- a/lib/objecheck/validator/regexp_rule.rb
+++ b/lib/objecheck/validator/regexp_rule.rb
@@ -1,0 +1,29 @@
+#
+# Objecheck
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# RegexpRule validates string by regular expression
+#
+class Objecheck::Validator::RegexpRule
+  def initialize(_validator, regexp)
+    @regexp = regexp
+  end
+
+  def validate(target, collector)
+    collector.add_error("should match to #{@regexp.inspect}") if !@regexp.match?(target)
+  rescue TypeError
+    collector.add_error("should be acceptable to Regexp (type is #{target.class})")
+  end
+end

--- a/spec/objecheck/validator/regexp_rule_spec.rb
+++ b/spec/objecheck/validator/regexp_rule_spec.rb
@@ -1,0 +1,36 @@
+describe Objecheck::Validator::RegexpRule do
+  let(:rule) { described_class.new(instance_double(Objecheck::Validator), regexp) }
+  let(:regexp) { /^[a-zA-Z_][a-zA-Z_0-9]*/ }
+
+  describe '#validate' do
+    subject { rule.validate(target, collector) }
+    let(:collector) { instance_double(Objecheck::Validator::Collector) }
+
+    context 'when target matches the given pattern' do
+      let(:target) { 'foo_bar_1' }
+
+      it 'dose not add error to collector' do
+        expect(collector).not_to receive(:add_error)
+        subject
+      end
+    end
+
+    context 'when target dose not match to the given object' do
+      let(:target) { '1_foo_bar' }
+
+      it 'add error to collector' do
+        expect(collector).to receive(:add_error).with("should match to #{regexp.inspect}")
+        subject
+      end
+    end
+
+    context 'when target is not acceptable to Regexp' do
+      let(:target) { 1 }
+
+      it 'add error to collector' do
+        expect(collector).to receive(:add_error).with("should be acceptable to Regexp (type is #{target.class})")
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix #13.

E.g:
```
{
  regexp: /\A[a-zA-Z_]\w*\z/
}
```